### PR TITLE
Add snyk monitor (closes #52)

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,20 @@
+name: Snyk
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Run Snyk to check for vulnerabilities
+      uses: snyk/actions/scala@master
+      with:
+        command: monitor
+        args: --project-name=stream-collector
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
This adds snyk monitor as gh action, just because it's a lot easier than configure the Travis at the moment and it should happen only on push to master I believe, so it's not needed to install snyk via npm in travis (and waste time for it on every build).