### PR TITLE
Allow collector to serve robots.txt file, fixes #109

### DIFF
--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
@@ -125,7 +125,7 @@ trait CollectorRoute {
           }
         }
       }
-    } ~ corsRoute ~ healthRoute ~ crossDomainRoute ~ rootRoute ~ {
+    } ~ corsRoute ~ healthRoute ~ crossDomainRoute ~ rootRoute ~ robotsRoute ~ {
       BeanRegistry.collectorBean.incrementFailedRequests()
       complete(HttpResponse(404, entity = "404 not found"))
     }
@@ -185,6 +185,12 @@ trait CollectorRoute {
   private def rootRoute: Route = get {
     pathSingleSlash {
       complete(collectorService.rootResponse)
+    }
+  }
+
+  private def robotsRoute: Route = get {
+    path("robots.txt".r) { _ =>
+      complete(HttpResponse(200, entity="User-agent: *\nDisallow: /"))
     }
   }
 

--- a/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRouteSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRouteSpec.scala
@@ -120,6 +120,11 @@ class CollectorRouteSpec extends Specification with Specs2RouteTest {
         responseAs[String] shouldEqual "404 not found"
       }
     }
+    "respond to robots.txt with a disallow rule" in {
+      Get("/robots.txt") ~> route.collectorRoute ~> check {
+        responseAs[String] shouldEqual "User-agent: *\nDisallow: /"
+      }
+    }
 
     "extract a query string" in {
       "produce the query string if present" in {


### PR DESCRIPTION
This allows the collector to serve a static text response at the `robots.txt` path.

With any luck this may have the side effect of reducing failed events (related to adapter failures) from crawlers that respect `robots.txt`. I considered allowing customisation for the response back but couldn't come up with any genuine reasons - though there may be some - as to why you might want to do this.