### PR TITLE
Add SQS collector module (close #120)

### DIFF
--- a/.github/workflows/deploy.sh
+++ b/.github/workflows/deploy.sh
@@ -8,7 +8,7 @@ project_version=$(sbt "project core" version -Dsbt.log.noformat=true | perl -ne 
 if [[ "${tag}" = *"${project_version}" ]]; then
   echo "Building and publishing assets (version $project_version)"
   echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-  sbt "project kinesis" docker:publish && sbt "project pubsub" docker:publish && sbt "project kafka" docker:publish && sbt "project nsq" docker:publish && sbt "project stdout" docker:publish
+  sbt "project kinesis" docker:publish && sbt "project pubsub" docker:publish && sbt "project kafka" docker:publish && sbt "project nsq" docker:publish && sbt "project stdout" docker:publish && sbt "project sqs" docker:publish
 else
   echo "Tag version '${tag}' doesn't match version in scala project ('${project_version}'). Aborting!"
   exit 1

--- a/build.sbt
+++ b/build.sbt
@@ -97,6 +97,18 @@ lazy val kinesis = project
   .enablePlugins(JavaAppPackaging, DockerPlugin)
   .dependsOn(core)
 
+lazy val sqs = project
+  .settings(moduleName := "snowplow-stream-collector-sqs")
+  .settings(allSettings)
+  .settings(packageName in Docker := "snowplow/scala-stream-collector-sqs")
+  .settings(
+    libraryDependencies ++= Seq(
+      Dependencies.Libraries.sqs
+    )
+  )
+  .enablePlugins(JavaAppPackaging, DockerPlugin)
+  .dependsOn(core)
+
 lazy val pubsub = project
   .settings(moduleName := "snowplow-stream-collector-google-pubsub")
   .settings(allSettings)

--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRoute.scala
@@ -125,7 +125,7 @@ trait CollectorRoute {
           }
         }
       }
-    } ~ corsRoute ~ healthRoute ~ crossDomainRoute ~ rootRoute ~ {
+    } ~ corsRoute ~ healthRoute ~ crossDomainRoute ~ rootRoute ~ robotsRoute ~ {
       BeanRegistry.collectorBean.incrementFailedRequests()
       complete(HttpResponse(404, entity = "404 not found"))
     }
@@ -185,6 +185,12 @@ trait CollectorRoute {
   private def rootRoute: Route = get {
     pathSingleSlash {
       complete(collectorService.rootResponse)
+    }
+  }
+
+  private def robotsRoute: Route = get {
+    path("robots.txt".r) { _ =>
+      complete(HttpResponse(200, entity = "User-agent: *\nDisallow: /"))
     }
   }
 

--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -95,6 +95,7 @@ package model {
   final case class CrossDomainConfig(enabled: Boolean, domains: List[String], secure: Boolean)
   final case class CORSConfig(accessControlMaxAge: FiniteDuration)
   final case class KinesisBackoffPolicyConfig(minBackoff: Long, maxBackoff: Long)
+  final case class SqsBackoffPolicyConfig(minBackoff: Long, maxBackoff: Long)
   final case class GooglePubSubBackoffPolicyConfig(
     minBackoff: Long,
     maxBackoff: Long,
@@ -117,6 +118,8 @@ package model {
       case _                 => s"https://kinesis.$region.amazonaws.com"
     })
   }
+  final case class Sqs(region: String, threadPoolSize: Int, aws: AWSConfig, backoffPolicy: SqsBackoffPolicyConfig)
+      extends SinkConfig
   final case class GooglePubSub(
     googleProjectId: String,
     backoffPolicy: GooglePubSubBackoffPolicyConfig

--- a/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRouteSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRouteSpec.scala
@@ -120,6 +120,11 @@ class CollectorRouteSpec extends Specification with Specs2RouteTest {
         responseAs[String] shouldEqual "404 not found"
       }
     }
+    "respond to robots.txt with a disallow rule" in {
+      Get("/robots.txt") ~> route.collectorRoute ~> check {
+        responseAs[String] shouldEqual "User-agent: *\nDisallow: /"
+      }
+    }
 
     "extract a query string" in {
       "produce the query string if present" in {

--- a/examples/config.hocon.sample
+++ b/examples/config.hocon.sample
@@ -209,7 +209,10 @@ collector {
     good = {{good}}
     good = ${?COLLECTOR_STREAMS_GOOD}
 
-    # Events that are too big (w.r.t Kinesis 1MB limit) will be stored in the bad stream/topic
+    # Bad rows (https://docs.snowplowanalytics.com/docs/try-snowplow/recipes/recipe-understanding-bad-data/) will be stored in the bad stream/topic.
+    # The collector can currently produce two flavours of bad row:
+    #  - a size_violation if an event is larger that the Kinesis (1MB) or SQS (256KB) limits;
+    #  - a generic_error if a request's querystring cannot be parsed because of illegal characters
     bad = {{bad}}
     bad = ${?COLLECTOR_STREAMS_BAD}
 
@@ -220,14 +223,14 @@ collector {
 
     # Enable the chosen sink by uncommenting the appropriate configuration
     sink {
-      # Choose between kinesis, google-pub-sub, kafka, nsq, or stdout.
+      # Choose between kinesis, sqs, google-pub-sub, kafka, nsq, or stdout.
       # To use stdout, comment or remove everything in the "collector.streams.sink" section except
       # "enabled" which should be set to "stdout".
-      enabled = kinesis
+      enabled = kinesis # or sqs
       enabled = ${?COLLECTOR_STREAMS_SINK_ENABLED}
 
       # Region where the streams are located
-      region = {{kinesisRegion}}
+      region = {{kinesisRegion}} # or {{sqsRegion}}
       region = ${?COLLECTOR_STREAMS_SINK_REGION}
 
       ## Optional endpoint url configuration to override aws kinesis endpoints,
@@ -235,20 +238,22 @@ collector {
       # customEndpoint = {{kinesisEndpoint}}
       # customEndpoint = ${?COLLECTOR_STREAMS_SINK_CUSTOM_ENDPOINT}
 
-      # Thread pool size for Kinesis API requests
+      # Thread pool size for Kinesis and SQS API requests
       threadPoolSize = 10
       threadPoolSize = ${?COLLECTOR_STREAMS_SINK_THREAD_POOL_SIZE}
 
       # Optional SQS buffer for good and bad events (respectively).
       # When messages can't be sent to Kinesis, they will be sent to SQS.
-      # If not configured, sending to Kinesis will be retried. 
+      # If not configured, sending to Kinesis will be retried.
+      # This should only be set up for the Kinesis sink, where it acts as a failsafe.
+      # For the SQS sink, the good and bad queue should be specified under streams.good and streams.bad, respectively and these settings should be ignored.
       sqsGoodBuffer = {{sqsGoodBuffer}}
       sqsGoodBuffer = ${?COLLECTOR_STREAMS_SINK_SQS_GOOD_BUFFER}
 
       sqsBadBuffer = {{sqsBadBuffer}}
       sqsBadBuffer = ${?COLLECTOR_STREAMS_SINK_SQS_BAD_BUFFER}
 
-      # The following are used to authenticate for the Amazon Kinesis sink.
+      # The following are used to authenticate for the Amazon Kinesis and SQS sinks.
       # If both are set to 'default', the default provider chain is used
       # (see http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html)
       # If both are set to 'iam', use AWS IAM Roles to provision credentials.

--- a/sqs/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/SqsCollector.scala
+++ b/sqs/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/SqsCollector.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2013-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0, and
+ * you may not use this file except in compliance with the Apache License
+ * Version 2.0.  You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Apache License Version 2.0 is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.collectors.scalastream
+
+import java.util.concurrent.ScheduledThreadPoolExecutor
+
+import cats.syntax.either._
+
+import com.snowplowanalytics.snowplow.collectors.scalastream.model._
+import com.snowplowanalytics.snowplow.collectors.scalastream.sinks.SqsSink
+
+object SqsCollector extends Collector {
+
+  def main(args: Array[String]): Unit = {
+    val (collectorConf, akkaConf) = parseConfig(args)
+
+    val sinks: Either[Throwable, CollectorSinks] = for {
+      sqs <- collectorConf.streams.sink match {
+        case sqs: Sqs => sqs.asRight
+        case sink     => new IllegalArgumentException(s"Configured sink $sink is not SQS.").asLeft
+      }
+      es         = new ScheduledThreadPoolExecutor(sqs.threadPoolSize)
+      goodQueue  = collectorConf.streams.good
+      badQueue   = collectorConf.streams.bad
+      bufferConf = collectorConf.streams.buffer
+      good <- SqsSink.createAndInitialize(sqs, bufferConf, goodQueue, es)
+      bad  <- SqsSink.createAndInitialize(sqs, bufferConf, badQueue, es)
+    } yield CollectorSinks(good, bad)
+
+    sinks match {
+      case Right(s) => run(collectorConf, akkaConf, s)
+      case Left(e)  => throw e
+    }
+  }
+}

--- a/sqs/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/SqsSink.scala
+++ b/sqs/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/SqsSink.scala
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2013-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.collectors.scalastream.sinks
+
+import java.nio.ByteBuffer
+import java.util.UUID
+import java.util.concurrent.ScheduledExecutorService
+
+import com.amazonaws.auth.{
+  AWSCredentialsProvider,
+  AWSStaticCredentialsProvider,
+  BasicAWSCredentials,
+  DefaultAWSCredentialsProviderChain,
+  EnvironmentVariableCredentialsProvider,
+  InstanceProfileCredentialsProvider
+}
+import com.amazonaws.services.sqs.{AmazonSQS, AmazonSQSClientBuilder}
+import com.amazonaws.services.sqs.model.{
+  QueueDoesNotExistException,
+  SendMessageBatchRequest,
+  SendMessageBatchRequestEntry
+}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ExecutionContextExecutorService, Future}
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.MILLISECONDS
+import scala.util.{Failure, Random, Success}
+
+import cats.syntax.either._
+
+import com.snowplowanalytics.snowplow.collectors.scalastream.model._
+
+/**
+  *  SQS sink for the Scala Stream Collector
+  */
+class SqsSink private (
+  client: AmazonSQS,
+  sqsConfig: Sqs,
+  bufferConfig: BufferConfig,
+  queueName: String,
+  executorService: ScheduledExecutorService
+) extends Sink {
+  // Records must not exceed 256K when writing to SQS.
+  // Since messages can be base64-encoded, they must meet that limit after encoding.
+  override val MaxBytes = 192000 // 256000 / 4 * 3
+
+  private val ByteThreshold: Long   = bufferConfig.byteLimit
+  private val RecordThreshold: Long = bufferConfig.recordLimit
+  private val TimeThreshold: Long   = bufferConfig.timeLimit
+
+  private val maxBackoff: Long        = sqsConfig.backoffPolicy.maxBackoff
+  private val minBackoff: Long        = sqsConfig.backoffPolicy.minBackoff
+  private val randomGenerator: Random = new java.util.Random()
+
+  implicit lazy val ec: ExecutionContextExecutorService =
+    concurrent.ExecutionContext.fromExecutorService(executorService)
+
+  def storeRawEvents(events: List[Array[Byte]], key: String): List[Array[Byte]] = {
+    events.foreach(e => EventBuffer.store(e))
+    Nil
+  }
+
+  object EventBuffer {
+    type Event = Array[Byte]
+
+    private var storedEvents              = List.empty[ByteBuffer]
+    private var byteCount                 = 0L
+    @volatile private var lastFlushedTime = 0L
+
+    def store(event: Event): Unit = {
+      val eventBytes = ByteBuffer.wrap(event)
+      val eventSize  = eventBytes.capacity
+      if (eventSize >= MaxBytes) {
+        log.error(
+          s"Message of size $eventSize bytes is too large. It must be less than $MaxBytes bytes."
+        )
+      } else {
+        synchronized {
+          if (storedEvents.size + 1 > RecordThreshold || byteCount + eventSize > ByteThreshold) {
+            flush()
+          }
+          storedEvents = eventBytes :: storedEvents
+          byteCount += eventSize
+        }
+      }
+    }
+
+    def flush(): Unit = {
+      val eventsToSend = synchronized {
+        val evts = storedEvents.reverse
+        storedEvents = Nil
+        byteCount    = 0
+        evts.map(_.array())
+      }
+      lastFlushedTime = System.currentTimeMillis()
+      sendBatch(eventsToSend)
+    }
+
+    def getLastFlushTime: Long = lastFlushedTime
+
+    /**
+      * Recursively schedule a task to flush the EventBuffer.
+      * Even if the incoming event flow dries up, all buffered events will eventually get sent.
+      * Whenever TimeThreshold milliseconds have passed since the last call to flush, call flush.
+      * @param interval When to schedule the next flush
+      */
+    def scheduleFlush(interval: Long = TimeThreshold): Unit = {
+      executorService.schedule(
+        new Thread {
+          override def run(): Unit = {
+            val lastFlushed = getLastFlushTime
+            val currentTime = System.currentTimeMillis()
+            if (currentTime - lastFlushed >= TimeThreshold) {
+              flush()
+              scheduleFlush(TimeThreshold)
+            } else {
+              scheduleFlush(TimeThreshold + lastFlushed - currentTime)
+            }
+          }
+        },
+        interval,
+        MILLISECONDS
+      )
+      ()
+    }
+  }
+
+  def sendBatch(batch: List[EventBuffer.Event], nextBackoff: Long = minBackoff): Unit =
+    if (batch.nonEmpty) {
+      log.info(s"Writing ${batch.size} Thrift records to SQS queue ${queueName}")
+
+      multiPut(batch).onComplete {
+        case Success(s) =>
+          log.info(s"Successfully wrote ${batch.size - s.size} out of ${batch.size} messages.")
+          if (s.nonEmpty) {
+            s.foreach { f =>
+              log.error(
+                s"Message failed with error code [${f._2.code}] and message [${f._2.message}]"
+              )
+            }
+            log.error(s"Retrying in $nextBackoff milliseconds...")
+            scheduleBatch(s.map(_._1), nextBackoff)
+          }
+        case Failure(f) =>
+          log.error("Writing failed.", f)
+          log.error(s"Retrying in $nextBackoff milliseconds...")
+          scheduleBatch(batch, nextBackoff)
+      }
+    }
+
+  /** @return Empty list in case of success, non-empty list of Events to be retried and the reasons why they failed to be inserted in case of problem. */
+  def multiPut(batch: List[EventBuffer.Event]): Future[List[(EventBuffer.Event, BatchResultErrorInfo)]] =
+    Future {
+      val MaxSqsBatchSize = 10 // SQS limit
+      batch
+        .map { e =>
+          (e, toSqsMessage(e))
+        }
+        .grouped(MaxSqsBatchSize)
+        .flatMap { msgGroup =>
+          val entries = msgGroup.map(_._2)
+          val batchRequest =
+            new SendMessageBatchRequest().withQueueUrl(queueName).withEntries(entries.asJava)
+          val response = client.sendMessageBatch(batchRequest)
+          val failures = response
+            .getFailed
+            .asScala
+            .toList
+            .map { bree =>
+              (bree.getId, BatchResultErrorInfo(bree.getCode, bree.getMessage))
+            }
+            .toMap
+          // Events to retry and reasons for failure
+          msgGroup.collect {
+            case (e, m) if failures.contains(m.getId) =>
+              (e, failures(m.getId))
+          }
+        }
+        .toList
+    }
+
+  def toSqsMessage(event: EventBuffer.Event): SendMessageBatchRequestEntry =
+    new SendMessageBatchRequestEntry(UUID.randomUUID.toString, b64Encode(event))
+
+  def b64Encode(e: EventBuffer.Event): String = {
+    val buffer = java.util.Base64.getEncoder.encode(e)
+    new String(buffer)
+  }
+
+  def scheduleBatch(batch: List[EventBuffer.Event], lastBackoff: Long = minBackoff): Unit = {
+    val nextBackoff = getNextBackoff(lastBackoff)
+    executorService.schedule(new Thread {
+      override def run(): Unit =
+        sendBatch(batch, nextBackoff)
+    }, lastBackoff, MILLISECONDS)
+    ()
+  }
+
+  /**
+    * How long to wait before sending the next request
+    * @param lastBackoff The previous backoff time
+    * @return Minimum of maxBackoff and a random number between minBackoff and three times lastBackoff
+    */
+  private def getNextBackoff(lastBackoff: Long): Long =
+    (minBackoff + randomGenerator.nextDouble() * (lastBackoff * 3 - minBackoff)).toLong.min(maxBackoff)
+
+  def shutdown(): Unit = {
+    executorService.shutdown()
+    executorService.awaitTermination(10000, MILLISECONDS)
+    ()
+  }
+
+  case class BatchResultErrorInfo private (code: String, message: String)
+}
+
+/**
+  *  SqsSink companion object with factory method
+  */
+object SqsSink {
+
+  /**
+    * Create an SqsSink and schedule a task to flush its EventBuffer.
+    * Exists so that no threads can get a reference to the SqsSink
+    * during its construction.
+    */
+  def createAndInitialize(
+    sqsConfig: Sqs,
+    bufferConfig: BufferConfig,
+    queueName: String,
+    executorService: ScheduledExecutorService
+  ): Either[Throwable, SqsSink] = {
+    val client = for {
+      provider <- getProvider(sqsConfig.aws)
+      client   <- createSqsClient(provider, sqsConfig.region)
+      _ = sqsQueueExists(client, queueName)
+    } yield client
+
+    client.map { c =>
+      val sqsSink = new SqsSink(c, sqsConfig, bufferConfig, queueName, executorService)
+      sqsSink.EventBuffer.scheduleFlush()
+
+      // When the application is shut down try to send all buffered events.
+      Runtime
+        .getRuntime
+        .addShutdownHook(new Thread {
+          override def run(): Unit = {
+            sqsSink.EventBuffer.flush()
+            sqsSink.shutdown()
+          }
+        })
+      sqsSink
+    }
+  }
+
+  private def createSqsClient(provider: AWSCredentialsProvider, region: String) =
+    Either.catchNonFatal(
+      AmazonSQSClientBuilder.standard().withRegion(region).withCredentials(provider).build
+    )
+
+  /**
+    * Check whether an SQS queue exists
+    * @param name Name of the queue
+    * @return Whether the queue exists
+    */
+  private def sqsQueueExists(client: AmazonSQS, name: String): Unit = {
+    lazy val log = LoggerFactory.getLogger(getClass)
+    try {
+      client.getQueueUrl(name)
+      ()
+    } catch {
+      case _: QueueDoesNotExistException => log.error(s"SQS queue $name does not exist.")
+      case t: Throwable                  => log.error(t.getMessage)
+    }
+  }
+
+  /** Create an aws credentials provider through env variables and iam. */
+  private def getProvider(awsConfig: AWSConfig): Either[Throwable, AWSCredentialsProvider] = {
+    def isDefault(key: String): Boolean = key == "default"
+    def isIam(key: String): Boolean     = key == "iam"
+    def isEnv(key: String): Boolean     = key == "env"
+
+    ((awsConfig.accessKey, awsConfig.secretKey) match {
+      case (a, s) if isDefault(a) && isDefault(s) =>
+        new DefaultAWSCredentialsProviderChain().asRight
+      case (a, s) if isDefault(a) || isDefault(s) =>
+        "accessKey and secretKey must both be set to 'default' or neither".asLeft
+      case (a, s) if isIam(a) && isIam(s) =>
+        InstanceProfileCredentialsProvider.getInstance().asRight
+      case (a, s) if isIam(a) && isIam(s) =>
+        "accessKey and secretKey must both be set to 'iam' or neither".asLeft
+      case (a, s) if isEnv(a) && isEnv(s) =>
+        new EnvironmentVariableCredentialsProvider().asRight
+      case (a, s) if isEnv(a) || isEnv(s) =>
+        "accessKey and secretKey must both be set to 'env' or neither".asLeft
+      case _ =>
+        new AWSStaticCredentialsProvider(
+          new BasicAWSCredentials(awsConfig.accessKey, awsConfig.secretKey)
+        ).asRight
+    }).leftMap(new IllegalArgumentException(_))
+  }
+}


### PR DESCRIPTION
You can run it locally:

```bash
$ sbt "project sqs" "run --config ./app.conf"
```

with `app.conf`:

```
collector {
  interface = "0.0.0.0"
  port = 12345

  paths {}

  p3p {
    policyRef = "/w3c/p3p.xml"
    CP = "NOI DSP COR NID PSA OUR IND COM NAV STA"
  }

  crossDomain {
    enabled = false
    domains = [ "*" ]
    secure = true
  }

  cookie {
    enabled = true
    expiration = "365 days"
    name = sp
    secure = false
    httpOnly = false
    sameSite = "None"
  }

  doNotTrackCookie {
    enabled = false
    name = dnt
    value = 1
  }

  cookieBounce {
    enabled = false
    name = "n3pc"
    fallbackNetworkUserId = "00000000-0000-4000-A000-000000000000"
    forwardedProtocolHeader = "X-Forwarded-Proto"
  }

  enableDefaultRedirect = false

  redirectMacro {
    enabled = false
    placeholder = "[TOKEN]"
  }

  rootResponse {
    enabled = false
    statusCode = 302
  }

  cors {
    accessControlMaxAge = 5 seconds
  }

  prometheusMetrics {
    enabled = false
  }

  streams {
    good = good
    bad = bad
    useIpAddressAsPartitionKey = false

    sink {
      enabled = sqs
      region = "eu-west-1"
      threadPoolSize = 10

      aws {
        accessKey = env
        secretKey = env
      }

      backoffPolicy {
        minBackoff = 1000
        maxBackoff = 10000
      }
    }

    buffer {
      byteLimit = 256000
      recordLimit = 10
      timeLimit = 5000
    }
  }

}

akka {
  loglevel = OFF
  loggers = []

  http.server {
    remote-address-header = on
    raw-request-uri-header = on
    parsing {
      max-uri-length = 32768
      uri-parsing-mode = relaxed
    }
  }
}
```