### PR TITLE
Set network_userid to empty UUID in anonymous mode to prevent collector_payload_format_violation

### DIFF
--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -243,7 +243,7 @@ class CollectorService(
     userAgent.foreach(e.userAgent   = _)
     refererUri.foreach(e.refererUri = _)
     e.hostname      = hostname
-    e.networkUserId = spAnonymous.fold(networkUserId)(_ => "")
+    e.networkUserId = spAnonymous.fold(networkUserId)(_ => "00000000-0000-0000-0000-000000000000")
     e.headers       = (headers(request, spAnonymous) ++ contentType).asJava
     contentType.foreach(e.contentType = _)
     e

--- a/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -143,7 +143,7 @@ class CollectorServiceSpec extends Specification {
         l must have size 1
         val newEvent = new CollectorPayload("iglu-schema", "ip", System.currentTimeMillis, "UTF-8", "collector")
         deserializer.deserialize(newEvent, l.head)
-        newEvent.networkUserId shouldEqual ""
+        newEvent.networkUserId shouldEqual "00000000-0000-0000-0000-000000000000"
       }
       "network_userid from cookie should persist if SP-Anonymous is not present" in {
         val (_, l) = service.cookie(
@@ -367,7 +367,7 @@ class CollectorServiceSpec extends Specification {
         e.userAgent shouldEqual "ua"
         e.refererUri shouldEqual "ref"
         e.hostname shouldEqual "h"
-        e.networkUserId shouldEqual ""
+        e.networkUserId shouldEqual "00000000-0000-0000-0000-000000000000"
         e.headers shouldEqual (List(l) ++ ct).map(_.toString).asJava
         e.contentType shouldEqual ct.get
       }
@@ -387,7 +387,7 @@ class CollectorServiceSpec extends Specification {
         e.userAgent shouldEqual "ua"
         e.refererUri shouldEqual "ref"
         e.hostname shouldEqual "h"
-        e.networkUserId shouldEqual ""
+        e.networkUserId shouldEqual "00000000-0000-0000-0000-000000000000"
         e.headers shouldEqual (List(l) ++ ct).map(_.toString).asJava
         e.contentType shouldEqual ct.get
       }
@@ -397,7 +397,7 @@ class CollectorServiceSpec extends Specification {
         val r  = HttpRequest().withHeaders(l :: hs)
         val e =
           service.buildEvent(None, Some("b"), "p", Some("ua"), Some("ref"), "h", "unknown", r, "nuid", ct, Some("*"))
-        e.networkUserId shouldEqual ""
+        e.networkUserId shouldEqual "00000000-0000-0000-0000-000000000000"
       }
       "have a nuid if SP-Anonymous is not present" in {
         val l  = `Location`("l")


### PR DESCRIPTION
When anonymous tracking is enabled in the JavaScript Tracker, as of version 2.1.2 we set the network_user to an empty string, which leads to collector_payload_format_violation errors downstream due to "" being an invalid UUID.

JavaScript Tracker (v2.17.3) example:
```
  <script type="text/javascript" async=1>
    ; (function (p, l, o, w, i, n, g) {
      if (!p[i]) {
        p.GlobalSnowplowNamespace = p.GlobalSnowplowNamespace || [];
        p.GlobalSnowplowNamespace.push(i); p[i] = function () {
          (p[i].q = p[i].q || []).push(arguments)
        }; p[i].q = p[i].q || []; n = l.createElement(o); g = l.getElementsByTagName(o)[0]; n.async = 1;
        n.src = w; g.parentNode.insertBefore(n, g)
      }
    }(window, document, "script", "https://cdn.jsdelivr.net/gh/snowplow/sp-js-assets@2.17.3/sp.js", "snowplow"));
  </script>

  <script>
    window.snowplow('newTracker', 'sp1', '{{COLLECTOR_URL}}', {
      appId: 'simple-test-1'
    });

    window.snowplow('enableAnonymousTracking', { withServerAnonymisation: true });
    window.snowplow('trackPageView');
  </script>
```
should have a `network_userid` of `00000000-0000-0000-0000-000000000000`.