### PR TITLE
Add option to restrict Access-Control-Allow-Origin header to certain domains

### DIFF
--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -93,7 +93,13 @@ package model {
   )
   final case class P3PConfig(policyRef: String, CP: String)
   final case class CrossDomainConfig(enabled: Boolean, domains: List[String], secure: Boolean)
-  final case class CORSConfig(accessControlMaxAge: FiniteDuration)
+  final case class CORSConfig(
+    accessControlMaxAge: FiniteDuration,
+    doRestrictDomains: Boolean              = true,
+    restrictDomainsTo: Option[List[String]] = None,
+  ) {
+    val restrictDomainsToConfig = if (doRestrictDomains) restrictDomainsTo else None
+  }
   final case class KinesisBackoffPolicyConfig(minBackoff: Long, maxBackoff: Long)
   final case class SqsBackoffPolicyConfig(minBackoff: Long, maxBackoff: Long)
   final case class GooglePubSubBackoffPolicyConfig(

--- a/examples/config.hocon.sample
+++ b/examples/config.hocon.sample
@@ -193,6 +193,14 @@ collector {
     # request can be cached. -1 seconds disables the cache. Chromium max is 10m, Firefox is 24h.
     accessControlMaxAge = 5 seconds
     accessControlMaxAge = ${?COLLECTOR_CORS_ACCESS_CONTROL_MAX_AGE}
+
+    # Whether or not the value in `restrictDomainsTo` is respected. Optional, defaults to true.
+    doRestrictDomains = false
+    doRestrictDomains = ${?COLLECTOR_CORS_ACCESS_CONTROL_DO_RESTRICT_DOMAINS}
+    # An optional list of domains to return the Access-Control-Allow-Origin header for. The header will
+    # not be returned for other domains. If this is not provided, it will be provided for all domains.
+    restrictDomainsTo = [ "example.com" ]
+    restrictDomainsTo = [ ${?COLLECTOR_CORS_RESTRICT_DOMAINS_TO} ]
   }
 
   # Configuration of prometheus http metrics


### PR DESCRIPTION
Closes #15.

Adds two options to the config file:

- `collector.cors.restrictDomainsTo`: the list of domains for which the ACAO header will be served. If not provided, it is served for all domains as it did prior to this change. For consistency, this has a corresponding environment variable `COLLECTOR_CORS_RESTRICT_DOMAINS_TO`; however using this is ill-advised as only a single domain can be supplied this way.
- `collector.cors.doRestrictDomains`: a boolean parameter that can be set to `false` to temporarily disable the functionality of `collector.cors.restrictDomainsTo`. Defaults to `true`. Corresponding environment variable is `COLLECTOR_CORS_ACCESS_CONTROL_DO_RESTRICT_DOMAINS`.

I've never worked with Scala or this codebase before, so I'm happy to change anything if it's not idiomatic.