### PR TITLE
[Part of akka upgrade] Remove akka.ssl-config from config

### DIFF
--- a/examples/config.hocon.sample
+++ b/examples/config.hocon.sample
@@ -353,22 +353,4 @@ akka {
       uri-parsing-mode = ${?AKKA_HTTP_SERVER_PARSING_URI_PARSING_MODE}
     }
   }
-
-  # By default setting `collector.ssl` relies on JSSE (Java Secure Socket
-  # Extension) to enable secure communication.
-  # To override the default settings set the following section as per
-  # https://lightbend.github.io/ssl-config/ExampleSSLConfig.html
-  # ssl-config {
-  #   debug = {
-  #     ssl = true
-  #   }
-  #   keyManager = {
-  #     stores = [
-  #       {type = "PKCS12", classpath = false, path = "/etc/ssl/mycert.p12", password = "mypassword" }
-  #     ]
-  #   }
-  #   loose {
-  #     disableHostnameVerification = false
-  #   }
-  # }
 }


### PR DESCRIPTION
akka-http 10.2.x deprecated APIs using `lightbend/ssl-config` and started to offer new APIs using `javax.net.ssl.SSLContext` which can be configured via Java system properties as explained in `Customizing JSSE` section in [Java 11 JSSE reference documentation](https://docs.oracle.com/en/java/javase/11/security/java-secure-socket-extension-jsse-reference-guide.html#GUID-A41282C3-19A3-400A-A40F-86F4DA22ABA9)


See [akka-http migration guide](https://doc.akka.io/docs/akka-http/current/migration-guide/migration-guide-10.2.x.html#configuring-https-connections) for details.