### PR TITLE
Enable AWS MSK IAM Authentication

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,7 +141,10 @@ lazy val kafka = project
   .settings(moduleName := "snowplow-stream-collector-kafka")
   .settings(allSettings)
   .settings(Docker / packageName := "scala-stream-collector-kafka")
-  .settings(libraryDependencies ++= Seq(Dependencies.Libraries.kafkaClients))
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.Libraries.kafkaClients,
+    Dependencies.Libraries.mskAuth
+  ))
   .enablePlugins(JavaAppPackaging, DockerPlugin, BuildInfoPlugin)
   .settings(buildInfoSettings)
   .dependsOn(core % "test->test;compile->compile")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,7 @@ object Dependencies {
     val awsSdk       = "1.12.128"
     val pubsub       = "1.115.0"
     val kafka        = "2.2.1"
+    val mskAuth      = "1.1.1"
     val nsqClient    = "1.3.0"
     val jodaTime     = "2.10.13"
     val slf4j        = "1.7.32"
@@ -60,6 +61,7 @@ object Dependencies {
     val sts              = "com.amazonaws"                    % "aws-java-sdk-sts"        % V.awsSdk % Runtime // Enables web token authentication https://github.com/snowplow/stream-collector/issues/169
     val pubsub           = "com.google.cloud"                 % "google-cloud-pubsub"     % V.pubsub
     val kafkaClients     = "org.apache.kafka"                 % "kafka-clients"           % V.kafka
+    val mskAuth          = "software.amazon.msk"              % "aws-msk-iam-auth"        % V.mskAuth
     val nsqClient        = "com.snowplowanalytics"            % "nsq-java-client"         % V.nsqClient
     val jodaTime         = "joda-time"                        % "joda-time"               % V.jodaTime
     val slf4j            = "org.slf4j"                        % "slf4j-simple"            % V.slf4j


### PR DESCRIPTION
Hey, 

we are using the managed Kafka Service MSK from AWS. To enable the IAM authentication (see (https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html) instead of certificate based authentication, an additional package is required so that the authentication can be enabled in the configuration: 

```conf
[...]
# Or Kafka (Comment out for other types)
brokers = "...."
producerConf {
  "security.protocol"="SASL_SSL"
  "sasl.mechanism"="AWS_MSK_IAM"
  "sasl.jaas.config"="software.amazon.msk.auth.iam.IAMLoginModule required;"
  "sasl.client.callback.handler.class"="software.amazon.msk.auth.iam.IAMClientCallbackHandler"
}
```

This pull request contains the required package. 

We already built it with `sbt 'project kafka' docker:stage` and made it work in our test environments. 

Let me know if you have some questions or if there is something to improve :)