### PR TITLE
Ignore warnings raised by illegal user agents

### DIFF
--- a/.github/workflows/integration_tests/telemetry/micro_config/config.hocon
+++ b/.github/workflows/integration_tests/telemetry/micro_config/config.hocon
@@ -79,6 +79,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
   }
  }

--- a/.github/workflows/ssc-collector-config/config.hocon
+++ b/.github/workflows/ssc-collector-config/config.hocon
@@ -84,6 +84,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
   }
 }

--- a/examples/config.hocon.sample
+++ b/examples/config.hocon.sample
@@ -375,6 +375,7 @@ akka {
       max-uri-length = ${?AKKA_HTTP_SERVER_PARSING_MAX_URI_LENGTH}
       uri-parsing-mode = relaxed
       uri-parsing-mode = ${?AKKA_HTTP_SERVER_PARSING_URI_PARSING_MODE}
+      ignore-illegal-header-for = ["user-agent"]
     }
   }
 }

--- a/examples/config.kafka.extended.hocon
+++ b/examples/config.kafka.extended.hocon
@@ -252,6 +252,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
 
     max-connections = 2048

--- a/examples/config.kinesis.extended.hocon
+++ b/examples/config.kinesis.extended.hocon
@@ -271,6 +271,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
 
     max-connections = 2048

--- a/examples/config.nsq.extended.hocon
+++ b/examples/config.nsq.extended.hocon
@@ -230,6 +230,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
 
     max-connections = 2048

--- a/examples/config.pubsub.extended.hocon
+++ b/examples/config.pubsub.extended.hocon
@@ -247,6 +247,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
 
     max-connections = 2048

--- a/examples/config.sqs.extended.hocon
+++ b/examples/config.sqs.extended.hocon
@@ -260,6 +260,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
 
     max-connections = 2048

--- a/examples/config.stdout.extended.hocon
+++ b/examples/config.stdout.extended.hocon
@@ -236,6 +236,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
 
     max-connections = 2048

--- a/kafka/src/main/resources/application.conf
+++ b/kafka/src/main/resources/application.conf
@@ -26,6 +26,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
 
     max-connections = 2048

--- a/kinesis/src/main/resources/application.conf
+++ b/kinesis/src/main/resources/application.conf
@@ -35,6 +35,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
 
     max-connections = 2048

--- a/nsq/src/main/resources/application.conf
+++ b/nsq/src/main/resources/application.conf
@@ -26,6 +26,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
 
     max-connections = 2048

--- a/pubsub/src/main/resources/application.conf
+++ b/pubsub/src/main/resources/application.conf
@@ -31,6 +31,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
 
     max-connections = 2048

--- a/sqs/src/main/resources/application.conf
+++ b/sqs/src/main/resources/application.conf
@@ -34,6 +34,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
 
     max-connections = 2048

--- a/stdout/src/main/resources/application.conf
+++ b/stdout/src/main/resources/application.conf
@@ -25,6 +25,7 @@ akka {
     parsing {
       max-uri-length = 32768
       uri-parsing-mode = relaxed
+      ignore-illegal-header-for = ["user-agent"]
     }
 
     max-connections = 2048


### PR DESCRIPTION
Copy of #179 with all the hocon / conf files updated inline to prevent the logging of warnings for invalid user agent (which turns out to be a lot of user agents).