### PR TITLE
Make collector timestamp timezone configurable

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -94,3 +94,5 @@ experimental {
     maxConnections = 2000
   }
 }
+
+timezone = "UTC"

--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/model.scala
@@ -21,6 +21,8 @@ import akka.http.scaladsl.model.headers.HttpCookiePair
 import com.snowplowanalytics.snowplow.collectors.scalastream.sinks.Sink
 
 import io.circe.Json
+import java.time.ZoneId
+
 
 package model {
 
@@ -214,7 +216,8 @@ package model {
     terminationDeadline: FiniteDuration,
     preTerminationPeriod: FiniteDuration,
     preTerminationUnhealthy: Boolean,
-    experimental: ExperimentalConfig
+    experimental: ExperimentalConfig,
+    timezone: Option[ZoneId]
   ) {
     val cookieConfig = if (cookie.enabled) Some(cookie) else None
     val doNotTrackHttpCookie =

--- a/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -361,7 +361,7 @@ class CollectorServiceSpec extends Specification {
         val xff = `X-Forwarded-For`(RemoteAddress(InetAddress.getByName("127.0.0.1")))
         val ct  = Some("image/gif")
         val r   = HttpRequest().withHeaders(l :: hs)
-        val e   = service.buildEvent(Some("q"), Some("b"), "p", Some("ua"), Some("ref"), "h", "ip", r, "nuid", ct, None)
+        val e   = service.buildEvent(Some("q"), Some("b"), "p", Some("ua"), Some("ref"), "h", "ip", r, "nuid", ct, None, None)
         e.schema shouldEqual "iglu:com.snowplowanalytics.snowplow/CollectorPayload/thrift/1-0-0"
         e.ipAddress shouldEqual "ip"
         e.encoding shouldEqual "UTF-8"
@@ -393,7 +393,8 @@ class CollectorServiceSpec extends Specification {
             r,
             nuid,
             ct,
-            Some("*")
+            Some("*"),
+            None
           )
         e.schema shouldEqual "iglu:com.snowplowanalytics.snowplow/CollectorPayload/thrift/1-0-0"
         e.ipAddress shouldEqual "unknown"
@@ -426,7 +427,8 @@ class CollectorServiceSpec extends Specification {
             r,
             nuid,
             ct,
-            Some("*")
+            Some("*"),
+            None
           )
         e.schema shouldEqual "iglu:com.snowplowanalytics.snowplow/CollectorPayload/thrift/1-0-0"
         e.ipAddress shouldEqual "unknown"
@@ -459,7 +461,8 @@ class CollectorServiceSpec extends Specification {
             r,
             nuid,
             ct,
-            Some("*")
+            Some("*"),
+            None
           )
         e.networkUserId shouldEqual "00000000-0000-0000-0000-000000000000"
       }
@@ -468,7 +471,7 @@ class CollectorServiceSpec extends Specification {
         val ct = Some("image/gif")
         val r  = HttpRequest().withHeaders(l :: hs)
         val e =
-          service.buildEvent(None, Some("b"), "p", Some("ua"), Some("ref"), "h", "ip", r, "nuid", ct, None)
+          service.buildEvent(None, Some("b"), "p", Some("ua"), Some("ref"), "h", "ip", r, "nuid", ct, None, None)
         e.networkUserId shouldEqual "nuid"
       }
     }

--- a/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/TestUtils.scala
+++ b/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/TestUtils.scala
@@ -66,6 +66,7 @@ object TestUtils {
       terminationDeadline     = 10.seconds,
       preTerminationPeriod    = 10.seconds,
       preTerminationUnhealthy = false,
-      experimental            = ExperimentalConfig(WarmupConfig(false, 2000, 2000))
+      experimental            = ExperimentalConfig(WarmupConfig(false, 2000, 2000)),
+      timezone                = None
     )
 }

--- a/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/config/ConfigSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/config/ConfigSpec.scala
@@ -24,6 +24,7 @@ import org.specs2.mutable.Specification
 import org.specs2.specification.core.{Fragment, Fragments}
 
 import java.nio.file.Paths
+import java.time.ZoneId
 import scala.concurrent.duration.DurationInt
 
 abstract class ConfigSpec extends Specification {
@@ -101,7 +102,8 @@ abstract class ConfigSpec extends Specification {
           ),
       sink = sinkConfigRefFactory(app)
     ),
-    experimental = ExperimentalConfig(WarmupConfig(false, 2000, 2000))
+    experimental = ExperimentalConfig(WarmupConfig(false, 2000, 2000)),
+    timezone     = Some(ZoneId.of("UTC"))
   )
 
   def sinkConfigRefFactory(app: String): SinkConfig = app match {


### PR DESCRIPTION
A customer wants to control the partition in BigQuery to avoid having to query multiple partitions. To make this possible, we want to control which timezone the current time millis are collected.

This should keep the default to UTC as System.currentTimeMillis is, but allow collectors that are in different timezones to be able to use a different timezone if needed.