### PR TITLE
Integration tests for /health endpoint and custom paths

### DIFF
--- a/core/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/Http.scala
+++ b/core/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/Http.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0, and
+ * you may not use this file except in compliance with the Apache License
+ * Version 2.0.  You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Apache License Version 2.0 is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.collectors.scalastream.it
+
+import scala.concurrent.ExecutionContext
+
+import cats.implicits._
+
+import cats.effect.{ContextShift, IO, Resource}
+
+import org.http4s.{Request, Status}
+import org.http4s.client.Client
+import org.http4s.client.blaze.BlazeClientBuilder
+
+object Http {
+
+  private val executionContext = ExecutionContext.global
+  implicit val ioContextShift: ContextShift[IO] = IO.contextShift(executionContext)
+
+  def sendRequests(requests: List[Request[IO]]): IO[List[Status]] =
+    mkClient.use { client => requests.traverse(client.status) }
+
+  def sendRequest(request: Request[IO]): IO[Status] =
+    mkClient.use { client => client.status(request) }
+
+  def mkClient: Resource[IO, Client[IO]] =
+    BlazeClientBuilder[IO](executionContext).resource
+}

--- a/kinesis/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/core/CustomPathsSpec.scala
+++ b/kinesis/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/core/CustomPathsSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0, and
+ * you may not use this file except in compliance with the Apache License
+ * Version 2.0.  You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Apache License Version 2.0 is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.collectors.scalastream.it.core
+
+import scala.concurrent.duration._
+
+import cats.effect.IO
+
+import cats.effect.testing.specs2.CatsIO
+
+import org.specs2.mutable.Specification
+
+import org.http4s.{Request, Method, Uri}
+
+import com.snowplowanalytics.snowplow.collectors.scalastream.it.kinesis.containers._
+import com.snowplowanalytics.snowplow.collectors.scalastream.it.kinesis.Kinesis
+import com.snowplowanalytics.snowplow.collectors.scalastream.it.Http
+
+class CustomPathsSpec extends Specification with Localstack with CatsIO {
+
+  override protected val Timeout = 5.minutes
+
+  "collector" should {
+    "map custom paths" in {
+      val testName = "custom-paths"
+      val streamGood = s"${testName}-raw"
+      val streamBad = s"${testName}-bad-1"
+
+      val originalPaths = List(
+        "/acme/track",
+        "/acme/redirect",
+        "/acme/iglu"
+      )
+      val targetPaths = List(
+        "/com.snowplowanalytics.snowplow/tp2",
+        "/r/tp2",
+        "/com.snowplowanalytics.iglu/v1"
+      )
+      val customPaths = originalPaths.zip(targetPaths)
+      val config = s"""
+      {
+        "collector": {
+          "paths": {
+            ${customPaths.map { case (k, v) => s""""$k": "$v""""}.mkString(",\n")}
+          }
+        }
+      }"""
+
+      Collector.container(
+        "kinesis/src/it/resources/collector.hocon",
+        testName,
+        streamGood,
+        streamBad,
+        Some(config)
+      ).use { collector =>
+        val host = collector.getHost()
+        val port = collector.getMappedPort(Collector.port)
+        val requests = originalPaths.map { p =>
+          val uri = Uri.unsafeFromString(s"http://$host:$port$p")
+          Request[IO](Method.POST, uri).withEntity("foo")
+        }
+
+        for {
+          _ <- Http.sendRequests(requests)
+          _ <- IO.sleep(5.second)
+          collectorOutput <- Kinesis.readOutput(streamGood, streamBad)
+          outputPaths = collectorOutput.good.map(cp => cp.getPath())
+        } yield {
+          outputPaths must beEqualTo(targetPaths)
+        }
+      }
+    }
+  }
+}

--- a/kinesis/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/core/HealthEndpointSpec.scala
+++ b/kinesis/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/core/HealthEndpointSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0, and
+ * you may not use this file except in compliance with the Apache License
+ * Version 2.0.  You may obtain a copy of the Apache License Version 2.0 at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Apache License Version 2.0 is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the Apache License Version 2.0 for the specific language
+ * governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.collectors.scalastream.it.core
+
+import scala.concurrent.duration._
+
+import cats.effect.IO
+
+import cats.effect.testing.specs2.CatsIO
+
+import org.specs2.mutable.Specification
+
+import org.http4s.{Request, Method, Uri}
+
+import com.snowplowanalytics.snowplow.collectors.scalastream.it.kinesis.containers._
+import com.snowplowanalytics.snowplow.collectors.scalastream.it.kinesis.Kinesis
+import com.snowplowanalytics.snowplow.collectors.scalastream.it.Http
+
+class HealthEndpointSpec extends Specification with Localstack with CatsIO {
+  
+  override protected val Timeout = 5.minutes
+
+  "collector" should {
+    "respond with 200 to /health endpoint after it has started" in {
+      val testName = "health-endpoint"
+      val streamGood = s"${testName}-raw"
+      val streamBad = s"${testName}-bad-1"
+      Collector.container(
+        "kinesis/src/it/resources/collector.hocon",
+        testName,
+        streamGood,
+        streamBad
+      ).use { collector =>
+        val host = collector.getHost()
+        val port = collector.getMappedPort(Collector.port)
+        val uri = Uri.unsafeFromString(s"http://$host:$port/health")
+        val request = Request[IO](Method.GET, uri)
+
+        for {
+          response <- Http.sendRequest(request)
+        _ <- IO.sleep(5.second)
+          collectorOutput <- Kinesis.readOutput(streamGood, streamBad)
+        } yield {
+          response.code must beEqualTo(200)
+          collectorOutput.good.size should beEqualTo(0)
+          collectorOutput.bad.size should beEqualTo(0)
+        }
+      }
+    }
+  }
+}

--- a/kinesis/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/kinesis/KinesisCollectorSpec.scala
+++ b/kinesis/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/kinesis/KinesisCollectorSpec.scala
@@ -21,7 +21,6 @@ import cats.effect.IO
 import cats.effect.testing.specs2.CatsIO
 
 import org.specs2.mutable.Specification
-import org.specs2.specification.BeforeAfterAll
 
 import org.testcontainers.containers.GenericContainer
 
@@ -30,13 +29,9 @@ import com.snowplowanalytics.snowplow.collectors.scalastream.it.EventGenerator
 
 import com.snowplowanalytics.snowplow.collectors.scalastream.it.kinesis.containers._
 
-class KinesisCollectorSpec extends Specification with CatsIO with BeforeAfterAll {
+class KinesisCollectorSpec extends Specification with Localstack with CatsIO {
 
   override protected val Timeout = 5.minutes
-
-  def beforeAll: Unit = Localstack.start()
-
-  def afterAll: Unit = Localstack.stop()
 
   val stopTimeout = 20.second
 
@@ -68,7 +63,7 @@ class KinesisCollectorSpec extends Specification with CatsIO with BeforeAfterAll
       ).use { collector =>
         for {
           _ <- log(testName, "Sending data")
-          _ <- EventGenerator.sendRequests(
+          _ <- EventGenerator.sendEvents(
             collector.getHost(),
             collector.getMappedPort(Collector.port),
             nbGood,

--- a/pubsub/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/pubsub/GooglePubSubCollectorSpec.scala
+++ b/pubsub/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/pubsub/GooglePubSubCollectorSpec.scala
@@ -63,7 +63,7 @@ class GooglePubSubCollectorSpec extends Specification with CatsIO with BeforeAft
       ).use { collector =>
         for {
           _ <- log(testName, "Sending data")
-          _ <- EventGenerator.sendRequests(
+          _ <- EventGenerator.sendEvents(
             collector.getHost(),
             collector.getMappedPort(Containers.collectorPort),
             nbGood,


### PR DESCRIPTION
Most interesting part is about having only one `localstack` container for all `specs2` `Specification`s, for which we can't define a global `beforeAll` and `afterAll` (unless I missed something).

So I created [this trait](https://github.com/snowplow/stream-collector/blob/feature/test_health/kinesis/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/kinesis/containers/Localstack.scala#L30-L34) that tests extend and I [use a `Semaphore`](https://github.com/snowplow/stream-collector/blob/feature/test_health/kinesis/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/kinesis/containers/Localstack.scala#L69-L73) to detect if a test is the last one and should stop `localstack`.