### PR TITLE
Run background check for Kinesis if it is made unhealthy and SQS buff…

### DIFF
--- a/pubsub/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/GooglePubSubSink.scala
+++ b/pubsub/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/GooglePubSubSink.scala
@@ -62,7 +62,7 @@ class GooglePubSubSink private (
 
   override def storeRawEvents(events: List[Array[Byte]], key: String): Unit =
     if (events.nonEmpty) {
-      log.info(s"Writing ${events.size} records to PubSub topic $topicName")
+      log.debug(s"Writing ${events.size} records to PubSub topic $topicName")
 
       events.foreach { event =>
         publisher.asRight.map { p =>


### PR DESCRIPTION
Here is the testing that I've done:
- Start the collector with both Kinesis stream and SQS buffer
- Send events
- Check that they are sent to Kinesis
- Delete Kinesis stream
- Send events
- Check that they are sent to SQS
- Create Kinesis stream
- Send events
- Check that they are sent to Kinesis
- Delete Kinesis stream
- Send events
- Check that they are sent to SQS
- Create Kinesis stream
- Send events
- Check that they are sent to Kinesis