### PR TITLE
Set maxBytes in the NsqSink

### DIFF
--- a/http4s/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Run.scala
+++ b/http4s/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Run.scala
@@ -25,12 +25,16 @@ import com.snowplowanalytics.snowplow.collector.core.model.Sinks
 
 object Run {
 
+  type MkSinks[F[_], SinkConfig] = Config.Streams[SinkConfig] => Resource[F, Sinks[F]]
+
+  type TelemetryInfo[SinkConfig] = Config[SinkConfig] => Telemetry.TelemetryInfo
+
   implicit private def logger[F[_]: Sync] = Slf4jLogger.getLogger[F]
 
   def fromCli[F[_]: Async: Tracking, SinkConfig: Decoder](
     appInfo: AppInfo,
-    mkSinks: Config.Streams[SinkConfig] => Resource[F, Sinks[F]],
-    telemetryInfo: Config[SinkConfig] => Telemetry.TelemetryInfo
+    mkSinks: MkSinks[F, SinkConfig],
+    telemetryInfo: TelemetryInfo[SinkConfig]
   ): Opts[F[ExitCode]] = {
     val configPath = Opts.option[Path]("config", "Path to HOCON configuration (optional)", "c", "config.hocon").orNone
     configPath.map(fromPath[F, SinkConfig](appInfo, mkSinks, telemetryInfo, _))
@@ -38,13 +42,13 @@ object Run {
 
   private def fromPath[F[_]: Async: Tracking, SinkConfig: Decoder](
     appInfo: AppInfo,
-    mkSinks: Config.Streams[SinkConfig] => Resource[F, Sinks[F]],
-    telemetryInfo: Config[SinkConfig] => Telemetry.TelemetryInfo,
+    mkSinks: MkSinks[F, SinkConfig],
+    telemetryInfo: TelemetryInfo[SinkConfig],
     path: Option[Path]
   ): F[ExitCode] = {
     val eitherT = for {
       config <- ConfigParser.fromPath[F, SinkConfig](path)
-      _      <- EitherT.right[ExitCode](fromConfig(appInfo, mkSinks, config, telemetryInfo))
+      _      <- EitherT.right[ExitCode](fromConfig(appInfo, mkSinks, telemetryInfo, config))
     } yield ExitCode.Success
 
     eitherT.merge.handleErrorWith { e =>
@@ -55,9 +59,9 @@ object Run {
 
   private def fromConfig[F[_]: Async: Tracking, SinkConfig](
     appInfo: AppInfo,
-    mkSinks: Config.Streams[SinkConfig] => Resource[F, Sinks[F]],
-    config: Config[SinkConfig],
-    telemetryInfo: Config[SinkConfig] => Telemetry.TelemetryInfo
+    mkSinks: MkSinks[F, SinkConfig],
+    telemetryInfo: TelemetryInfo[SinkConfig],
+    config: Config[SinkConfig]
   ): F[ExitCode] = {
     val resources = for {
       sinks <- mkSinks(config.streams)

--- a/nsq/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/NsqCollector.scala
+++ b/nsq/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/NsqCollector.scala
@@ -23,10 +23,12 @@ object NsqCollector extends App[NsqSinkConfig](BuildInfo) {
   override def mkSinks(config: Config.Streams[NsqSinkConfig]): Resource[IO, Sinks[IO]] =
     for {
       good <- NsqSink.create[IO](
+        config.sink.maxBytes,
         config.sink,
         config.good
       )
       bad <- NsqSink.create[IO](
+        config.sink.maxBytes,
         config.sink,
         config.bad
       )

--- a/nsq/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/NsqSink.scala
+++ b/nsq/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/NsqSink.scala
@@ -65,14 +65,13 @@ class NsqSink[F[_]: Sync] private (
 object NsqSink {
 
   def create[F[_]: Sync](
+    maxBytes: Int,
     nsqConfig: NsqSinkConfig,
     topicName: String
   ): Resource[F, NsqSink[F]] =
     Resource.make(
       Sync[F].delay(
-        // MaxBytes is never used but is required by the sink interface definition,
-        // So just pass any int val in.
-        new NsqSink(0, nsqConfig, topicName)
+        new NsqSink(maxBytes, nsqConfig, topicName)
       )
     )(sink => Sync[F].delay(sink.shutdown()))
 }


### PR DESCRIPTION
We need `maxBytes` because it is used in the [Service class](https://github.com/snowplow/stream-collector/blob/c6982c8f868b43e27083e148780d7a72112e510f/http4s/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Service.scala#L264).