### PR TITLE
Cross compile to scala 2.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check formatting
         run: sbt scalafmtCheckAll
       - name: Run unit tests
-        run: sbt test
+        run: sbt +test
       - name: Run integration tests Kinesis
         run: sbt "project kinesisDistroless" IntegrationTest/test
       - name: Run integration tests PubSub

--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/HttpServer.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/HttpServer.scala
@@ -58,7 +58,7 @@ object HttpServer {
 
   private def createStatsdConfig(metricsConfig: Config.Metrics): StatsDMetricFactoryConfig = {
     val server = InetSocketAddress.createUnresolved(metricsConfig.statsd.hostname, metricsConfig.statsd.port)
-    val tags   = metricsConfig.statsd.tags.toSeq.map { case (name, value) => Tag.of(name, value) }
+    val tags   = metricsConfig.statsd.tags.toVector.map { case (name, value) => Tag.of(name, value) }
     StatsDMetricFactoryConfig(Some(metricsConfig.statsd.prefix), server, defaultTags = tags)
   }
 

--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Service.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Service.scala
@@ -193,8 +193,7 @@ class Service[F[_]: Sync](
     config.doNotTrackCookie.enabled && req
       .cookies
       .find(_.name == config.doNotTrackCookie.name)
-      .map(cookie => config.doNotTrackCookie.value.r.matches(cookie.content))
-      .getOrElse(false)
+      .exists(cookie => config.doNotTrackCookie.value.r.pattern.matcher(cookie.content).matches())
 
   def extractHostname(req: Request[F]): Option[String] =
     req.uri.authority.map(_.host.renderString) // Hostname is extracted like this in Akka-Http as well

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -27,6 +27,7 @@ object BuildSettings {
     name           := "snowplow-stream-collector",
     description    := "Scala Stream Collector for Snowplow raw events",
     scalaVersion   := "2.13.12",
+    crossScalaVersions := Seq("2.13.12", "2.12.14"),
     scalacOptions ++= Seq("-Ywarn-macros:after"),
     javacOptions   := Seq("-source", "11", "-target", "11"),
     resolvers     ++= Seq(


### PR DESCRIPTION
This is implemented, because we need both Collector and Enrich in Micro. It turns out it's easier to ad cross compile to 2.12 in Collector, than upgrade Enrich to 2.13. This should be temporary solution, we need to have everything running on 2.13 eventually.