### PR TITLE
Upcase cookie header name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-Release 3.0.1 (2024-01-10)
+Release 3.1.1 (2024-02-20)
++--------------------------
+Upcase cookie header name (#412)
+
+Release 3.1.0 (2024-01-25)
 --------------------------
 Add an option to send HSTS header (#408)
 

--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Service.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Service.scala
@@ -304,7 +304,10 @@ class Service[F[_]: Sync](
     request.headers.headers.flatMap { h =>
       h.name match {
         case ci"X-Forwarded-For" | ci"X-Real-Ip" | ci"Cookie" if spAnonymous.isDefined => None
-        case _ => Some(h.toString())
+        // FIXME: This is a temporary backport of old akka behaviour we will remove by
+        //        adapting enrich to support a CIString header names as per RFC7230#Section-3.2
+        case ci"Cookie" => Some(s"Cookie: ${h.value}")
+        case _          => Some(h.toString())
       }
     }
 


### PR DESCRIPTION
Since migrating to http4s we observed a flaw in cookie processing.
Previously, with akka the headers were uppercased. 
Http4s follows RFC[1] related to header names more closely ignoring the case.
This had a result in missing cookie extractions in enrich that only supports upper case Cookie header.

We are making enrich case-insensitive. Meanwhile, until the change is migrated this is a workaround that will upcase cookie header.

1 -  https://www.rfc-editor.org/rfc/rfc7230#section-3.2