### PR TITLE
Make cookie bounce return a completely relative URI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Release 3.1.2 (2024-02-22)
++--------------------------
+Improve relative redirect in cookie bounce feature (#413)
+
 Release 3.1.1 (2024-02-20)
 +--------------------------
 Upcase cookie header name (#412)


### PR DESCRIPTION
Previously it was possible to return an absolute URI that would would
not work in relative redirects in nginx. This makes relative URIs complete.

Bit of a defensive coding but makes things explicit.