### PR TITLE
Add QA framework job for builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,3 +150,28 @@ jobs:
           command: monitor
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+  qa_framework:
+    runs-on: ubuntu-latest
+    needs: deploy_to_docker
+    steps:
+      - uses: actions/checkout@v2
+      - uses: coursier/cache-action@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Get current version
+        id: ver
+        run: |
+          export PROJECT_VERSION=$(sbt "project core" version -Dsbt.log.noformat=true | perl -ne 'print "$1\n" if /info.*(\d+\.\d+\.\d+[^\r\n]*)/' | tail -n 1 | tr -d '\n')
+          echo "project_version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
+      - name: Execute QA Framework tests
+        uses: aurelien-baudet/workflow-dispatch@v2
+        with:
+          workflow: test-component
+          repo: snowplow-devops/qa-framework
+          token: ${{ secrets.GLOBAL_QA_FRAMEWORK_PAT }}
+          ref: "refs/heads/main"
+          inputs: '{ "test_directory": "collector", "qa_collector_version": "${{ steps.ver.outputs.project_version }}" }'
+          wait-for-completion-timeout: 30m # workflow is much slower in Azure; can take up to 20-something minutes
+          display-workflow-run-url: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -173,5 +173,5 @@ jobs:
           token: ${{ secrets.GLOBAL_QA_FRAMEWORK_PAT }}
           ref: "refs/heads/main"
           inputs: '{ "test_directory": "collector", "qa_collector_version": "${{ steps.ver.outputs.project_version }}" }'
-          wait-for-completion-timeout: 30m # workflow is much slower in Azure; can take up to 20-something minutes
+          wait-for-completion-timeout: 60m # workflow is much slower in Azure; can take up to 20-something minutes
           display-workflow-run-url: true


### PR DESCRIPTION
QA framework[1] is an end-to-end testing suite for Snowplow services. It runs a desired configuration for pipeline components in a real-life cloud deployment.

This change adds a trigger for automatically running QA framework for tag builds. Why all tag builds? These tags are added for when we decide to evaluate an asset in a cloud environment. Final rc builds don't differ much from stable tags. Therefore, testing the stable asset should be a formality and should not be a blocking step.

Why don't we retag stable asset after testing? This option has been tested. The change is relatively simple in the script - skopeo[2] can retag images without pulling them. However, as an image needs to be accessible for it to be deployed it needs a temporary tag (including a commit ref ideally). This however extends the build and as stable release is usually a retag of the final rc, the benefit is minimal. We may however, revisit this in the future.

Why don't we run it for all PRs? Well, it takes ages to run these things. It's simple enough to create an rc if you need it.

1 - https://github.com/snowplow-devops/qa-framework 
2 - https://github.com/containers/skopeo