### PR TITLE
Bump transitive jnr-posix to 3.1.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val core = project
       Dependencies.Libraries.specs2,
       Dependencies.Libraries.specs2CE,
       Dependencies.Libraries.ceTestkit,
+      Dependencies.Libraries.jnrPosix,
 
       //Integration tests
       Dependencies.Libraries.IntegrationTests.testcontainers,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,6 +40,7 @@ object Dependencies {
     val thrift           = "0.15.0" // force this version to mitigate security vulnerabilities
     val tracker          = "2.0.0"
     val dataDog4s        = "0.32.0"
+    val jnrPosix         = "3.1.8"  // force this version to mitigate security vulnerabilities
     val azureIdentity    = "1.11.0"
   }
 
@@ -62,7 +63,8 @@ object Dependencies {
     val trackerCore       = "com.snowplowanalytics" %% "snowplow-scala-tracker-core"           % V.tracker
     val datadogHttp4s     = "com.avast.cloud"       %% "datadog4s-http4s"                      % V.dataDog4s
     val datadogStatsd     = "com.avast.cloud"       %% "datadog4s-statsd"                      % V.dataDog4s
-    
+    val jnrPosix          = "com.github.jnr"        % "jnr-posix"                              % V.jnrPosix
+
     //sinks
     val fs2PubSub      = "com.permutive"              %% "fs2-google-pubsub-grpc"     % V.fs2PubSub
     val jackson        = "com.fasterxml.jackson.core" % "jackson-databind"            % V.jackson


### PR DESCRIPTION
Minimum Java 8 seems to be the only major change between `series/3.0.x`
and `series/3.1.x`.
Addresses CWE-416[1] w/o known exploit. 

1 - https://cwe.mitre.org/data/definitions/416