### PR TITLE
Disable timeouts on healthcheck calls

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -94,7 +94,7 @@
   networking {
     maxConnections = 1024
     idleTimeout = 610 seconds
-    responseHeaderTimeout = 5 seconds
+    responseHeaderTimeout = 30 seconds
     maxRequestLineLength = 20480
     maxHeadersLength = 40960
   }

--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Run.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Run.scala
@@ -93,13 +93,15 @@ object Run {
         Sinks(sinks.good, sinks.bad),
         appInfo
       )
+      routes = new Routes[F](
+        config.enableDefaultRedirect,
+        config.rootResponse.enabled,
+        config.crossDomain.enabled,
+        collectorService
+      )
       httpServer = HttpServer.build[F](
-        new Routes[F](
-          config.enableDefaultRedirect,
-          config.rootResponse.enabled,
-          config.crossDomain.enabled,
-          collectorService
-        ).value,
+        routes.value,
+        routes.health,
         if (config.ssl.enable) config.ssl.port else config.port,
         config.ssl.enable,
         config.hsts,

--- a/core/src/test/scala/com.snowplowanalytics.snowplow.collector.core/RoutesSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.snowplow.collector.core/RoutesSpec.scala
@@ -5,6 +5,7 @@ import cats.data.NonEmptyList
 import scala.collection.mutable.ListBuffer
 import org.specs2.mutable.Specification
 import cats.effect.IO
+import cats.syntax.all._
 import cats.effect.unsafe.implicits.global
 import org.http4s.implicits._
 import org.http4s._
@@ -73,8 +74,8 @@ class RoutesSpec extends Specification {
   ) = {
     val service = new TestService()
     val routes =
-      new Routes(enabledDefaultRedirect, enableRootResponse, enableCrossdomainTracking, service).value.orNotFound
-    val routesWithHsts = HttpServer.hstsMiddleware(Config.HSTS(enableHsts, 180.days), routes)
+      new Routes(enabledDefaultRedirect, enableRootResponse, enableCrossdomainTracking, service)
+    val routesWithHsts = HttpServer.hstsApp(Config.HSTS(enableHsts, 180.days), (routes.value <+> routes.health))
     (service, routesWithHsts)
   }
 

--- a/core/src/test/scala/com.snowplowanalytics.snowplow.collector.core/TestUtils.scala
+++ b/core/src/test/scala/com.snowplowanalytics.snowplow.collector.core/TestUtils.scala
@@ -120,7 +120,7 @@ object TestUtils {
     networking = Networking(
       1024,
       610.seconds,
-      5.seconds,
+      30.seconds,
       20480,
       40960
     ),

--- a/kafka/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/KafkaConfigSpec.scala
+++ b/kafka/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/KafkaConfigSpec.scala
@@ -171,7 +171,7 @@ object KafkaConfigSpec {
     networking = Config.Networking(
       maxConnections        = 1024,
       idleTimeout           = 610.seconds,
-      responseHeaderTimeout = 5.seconds,
+      responseHeaderTimeout = 30.seconds,
       maxRequestLineLength  = 20480,
       maxHeadersLength      = 40960
     ),

--- a/kinesis/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/KinesisConfigSpec.scala
+++ b/kinesis/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/KinesisConfigSpec.scala
@@ -125,7 +125,7 @@ object KinesisConfigSpec {
     networking = Config.Networking(
       maxConnections        = 1024,
       idleTimeout           = 610.seconds,
-      responseHeaderTimeout = 5.seconds,
+      responseHeaderTimeout = 30.seconds,
       maxRequestLineLength  = 20480,
       maxHeadersLength      = 40960
     ),

--- a/nsq/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/NsqConfigSpec.scala
+++ b/nsq/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/NsqConfigSpec.scala
@@ -158,7 +158,7 @@ object NsqConfigSpec {
     networking = Config.Networking(
       maxConnections        = 1024,
       idleTimeout           = 610.seconds,
-      responseHeaderTimeout = 5.seconds,
+      responseHeaderTimeout = 30.seconds,
       maxRequestLineLength  = 20480,
       maxHeadersLength      = 40960
     ),

--- a/pubsub/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/ConfigSpec.scala
+++ b/pubsub/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/ConfigSpec.scala
@@ -114,7 +114,7 @@ object ConfigSpec {
     networking = Config.Networking(
       maxConnections        = 1024,
       idleTimeout           = 610.seconds,
-      responseHeaderTimeout = 5.seconds,
+      responseHeaderTimeout = 30.seconds,
       maxRequestLineLength  = 20480,
       maxHeadersLength      = 40960
     ),

--- a/sqs/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/SqsConfigSpec.scala
+++ b/sqs/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/SqsConfigSpec.scala
@@ -115,7 +115,7 @@ object SqsConfigSpec {
     networking = Config.Networking(
       maxConnections        = 1024,
       idleTimeout           = 610.seconds,
-      responseHeaderTimeout = 5.seconds,
+      responseHeaderTimeout = 30.seconds,
       maxRequestLineLength  = 20480,
       maxHeadersLength      = 40960
     ),


### PR DESCRIPTION
Currently, health checks reside behind the same timeout settings as any other endpoint. We observed that when autoscaling under massive load, it is possible for collector to be taken down because of long health check responses.
Which previously did not happen. We therefore move health checks above the timeout middleware to return to previous behavior. Additionally, this allows us to set arbitrarily short (or long) response times for the regular endpoints when necessary.

We also update default health checks to match what we typically set by default.

---

Part of [PDP-1408]

[PDP-1408]: https://snplow.atlassian.net/browse/PDP-1408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ