### PR TITLE
PDP-1526 Remove parts of the cookies that are not valid according to RFC 6265

### DIFF
--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Rfc6265Cookie.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Rfc6265Cookie.scala
@@ -1,0 +1,28 @@
+/**
+  * Copyright (c) 2013-present Snowplow Analytics Ltd.
+  * All rights reserved.
+  *
+  * This software is made available by Snowplow Analytics, Ltd.,
+  * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+  * located at https://docs.snowplow.io/limited-use-license-1.0
+  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+  */
+package com.snowplowanalytics.snowplow.collector.core
+
+object Rfc6265Cookie {
+
+  // See https://www.ietf.org/rfc/rfc6265.txt
+  private val allowedChars = Set(0x21.toChar) ++
+    Set(0x23.toChar to 0x2b.toChar: _*) ++
+    Set(0x2d.toChar to 0x3a.toChar: _*) ++
+    Set(0x3c.toChar to 0x5b.toChar: _*) ++
+    Set(0x5d.toChar to 0x7e.toChar: _*)
+
+  // Remove all the sub-parts (between two ';') that contain unauthorized characters
+  def parse(rawCookie: String): Option[String] =
+    rawCookie.replaceAll(" ", "").split(";").filter(_.forall(allowedChars.contains)).mkString(";") match {
+      case s if s.nonEmpty => Some(s)
+      case _               => None
+    }
+}

--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Service.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Service.scala
@@ -305,7 +305,7 @@ class Service[F[_]: Sync](
         case ci"X-Forwarded-For" | ci"X-Real-Ip" | ci"Cookie" if spAnonymous.isDefined => None
         // FIXME: This is a temporary backport of old akka behaviour we will remove by
         //        adapting enrich to support a CIString header names as per RFC7230#Section-3.2
-        case ci"Cookie" => Some(s"Cookie: ${h.value}")
+        case ci"Cookie" => Rfc6265Cookie.parse(h.value).map(c => s"Cookie: $c")
         case _          => Some(h.toString())
       }
     }

--- a/core/src/test/scala/com.snowplowanalytics.snowplow.collector.core/Rfc6265CookieSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.snowplow.collector.core/Rfc6265CookieSpec.scala
@@ -1,0 +1,35 @@
+package com.snowplowanalytics.snowplow.collector.core
+
+import org.specs2.mutable.Specification
+
+class Rfc6265CookieSpec extends Specification {
+  val valid1    = "name=value"
+  val valid2    = "name1=value2"
+  val bothValid = s"$valid1;$valid2"
+  val invalid   = "{\"key\": \"value\"}"
+
+  "Rfc6265Cookie.parse" should {
+    "leave a valid cookie as is" in {
+      Rfc6265Cookie.parse(valid1) must beSome(valid1)
+      Rfc6265Cookie.parse(bothValid) must beSome(bothValid)
+    }
+
+    "remove whitespaces" in {
+      Rfc6265Cookie.parse(s" $valid1 ") must beSome(valid1)
+      Rfc6265Cookie.parse("name = value") must beSome(valid1)
+    }
+
+    "remove invalid parts" in {
+      Rfc6265Cookie.parse(s"$invalid;$valid1;$valid2") must beSome(bothValid)
+      Rfc6265Cookie.parse(s"$valid1;$invalid;$valid2") must beSome(bothValid)
+      Rfc6265Cookie.parse(s"$valid1;$valid2;$invalid") must beSome(bothValid)
+    }
+
+    "return None if no valid part is left" in {
+      Rfc6265Cookie.parse(invalid) must beNone
+      Rfc6265Cookie.parse(s";$invalid;") must beNone
+      Rfc6265Cookie.parse(";") must beNone
+      Rfc6265Cookie.parse(";;") must beNone
+    }
+  }
+}

--- a/core/src/test/scala/com.snowplowanalytics.snowplow.collector.core/ServiceSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.snowplow.collector.core/ServiceSpec.scala
@@ -249,7 +249,7 @@ class ServiceSpec extends Specification {
           "Content-Type: application/json",
           "X-Forwarded-For: 192.0.2.3",
           "Access-Control-Allow-Credentials: true",
-          "Cookie: cookie=value; sp=dfdb716e-ecf9-4d00-8b10-44edfbc8a108",
+          "Cookie: cookie=value;sp=dfdb716e-ecf9-4d00-8b10-44edfbc8a108",
           "image/gif"
         ).asJava
         e.contentType shouldEqual "image/gif"


### PR DESCRIPTION
The issue is described in https://github.com/snowplow/enrich/issues/904

## Comparison between Collector 2.x and 3.x

### Collector 3.2.0

#### json after

Input : `Cookie: wanted_cookie=crucial_value; AS_JSON={\"Key\":\"Value\"};`
Output : `Cookie: wanted_cookie=crucial_value; AS_JSON={\"Key\":\"Value\"};`

#### json before

Input : `Cookie: AS_JSON={\"Key\":\"Value\"}; wanted_cookie=crucial_value;`
Output : `Cookie: AS_JSON={\"Key\":\"Value\"}; wanted_cookie=crucial_value;`

### Collector 2.10.0

#### json after

Input : `Cookie: wanted_cookie=crucial_value; AS_JSON={\"Key\":\"Value\"};`
Output : `Cookie: wanted_cookie=crucial_value`

#### json before

Input : `Cookie: AS_JSON={\"Key\":\"Value\"}; wanted_cookie=crucial_value;`
Output : `Cookie: wanted_cookie=crucial_value`

### Conclusion

Collector 2.x removes the invalid part while collector 3.x leaves the cookie as is.

These are the characters allowed in the [RFC 6265](https://www.ietf.org/rfc/rfc6265.txt):
```
scala> val allowedChars = Set(0x21.toChar) ++ Set(0x23.toChar to 0x2b.toChar: _*) ++ Set(0x2d.toChar to 0x3a.toChar: _*) ++ Set(0x3c.toChar to 0x5b.toChar: _*) ++ Set(0x5d.toChar to 0x7e.toChar: _*)
allowedChars: scala.collection.immutable.Set[Char] = Set(E, e, X, s, x, 8, *, %, 4, n, }, ., ], 9, N, j, y, T, =, Y, t, J, <, u, U, f, &, F, !, A, a, 5, m, |, M, `, ), I, i, -, @, v, G, 6, 1, V, q, Q, L, ', b, g, [, B, l, P, #, p, {, 0, ?, _, 2, C, H, +, c, W, h, (, 7, r, K, w, :, R, $, 3, k, ~, O, ^, /, D, >, Z, o, z, S, d)
```
The following characters of the above cookies are not part of this list: `space`, `"`, `\`.

## Solutions

### 1. Update Enrich to deal with invalid cookies

As it is nearly impossible to foresee everything that could be wrong with the format of the cookies, it does not seem like a good idea.
 
### 2. Use strict parsing

At the moment, the collector [doesn't parse](https://github.com/snowplow/stream-collector/blob/3.2.0/core/src/main/scala/com.snowplowanalytics.snowplow.collector.core/Service.scala#L308) the value of a cookie, it just leaves it as is.

If we use `http4s`' [cookie parser](https://github.com/http4s/http4s/blob/series/0.23/core/shared/src/main/scala/org/http4s/RequestCookie.scala#L35), by default the [relaxed parser](https://github.com/http4s/http4s/blob/series/0.23/core/shared/src/main/scala/org/http4s/internal/parsing/Cookies.scala#L64) is used, which leaves us in the same situation as we are now (I tried).

If instead we use [RFC 6265 parser](https://github.com/http4s/http4s/blob/series/0.23/core/shared/src/main/scala/org/http4s/internal/parsing/Cookies.scala#L44), then the parsing of the cookie fails:

```
Left(org.http4s.ParseFailure: Invalid Cookie header: AS_JSON={\"Key\":\"Value\"}; wanted_cookie=crucial_value;
         ^
expectation:
* must end the string)
```

FYI [this](https://github.com/http4s/http4s/blob/series/0.23/core/shared/src/main/scala/org/http4s/headers/Cookie.scala#L49) is where the parsing of cookies happens in `http4s`.

### 3. Manually remove invalid parts

This consists in removing all the cookie's sub-parts (surrounded by `;`) that contain at least a character that is not allowed by the RFC 6265.

I'm in favor of this solution. It seems safe (all cookies valid according to the RFC are left untouched) and it puts back `2.x`'s behavior.